### PR TITLE
Fixes to work on gnome-shell 3.10 (addActor method removed on PopupMenu)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -169,7 +169,7 @@ TasksManager.prototype =
 		bottomSection.actor.add_actor(this.newTask);
 		bottomSection.actor.add_style_class_name("newTaskSection");
 		this.mainBox.add_actor(bottomSection.actor);
-		tasksMenu.addActor(this.mainBox);
+		tasksMenu.box.add(this.mainBox);
 	},
 	
 	_enable: function()

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "description": "Simple todo list extension. You can add and remove task on your list.", 
   "name": "Todo list", 
   "shell-version": [
-  "3.8"
+  "3.10"
   ], 
   "url": "https://github.com/bsaleil/todolist-gnome-shell-extension", 
   "uuid": "todolist@bsaleil.org"


### PR DESCRIPTION
Tested on Fedora 20 (GNOME Shell 3.10.2.1). 

Regards, Magnus
