### PR TITLE
Fix global keyboard shortcut (+version 3.18)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -158,15 +158,25 @@ TodoList.prototype._refresh = function(){
 	// Restore hint text
 	this.newTask.hint_text = _("New task...");
 
+        this._addKeybinding();
 }
 
 // Enable method
 TodoList.prototype._enable = function() {
 	// Conect file 'changed' signal to _refresh
 	let fileM = Gio.file_new_for_path(this.filePath);
-	let mode = Shell.ActionMode ? Shell.ActionMode.ALL : Shell.KeyBindingMode.ALL;
 	this.monitor = fileM.monitor(Gio.FileMonitorFlags.NONE, null);
 	this.monitor.connect('changed', Lang.bind(this, this._refresh));
+
+        this._addKeybinding();
+}
+
+// Enable method
+TodoList.prototype._addKeybinding = function() {
+	let mode = Shell.ActionMode ? Shell.ActionMode.ALL : Shell.KeyBindingMode.ALL;
+
+        // Remove to avoid duplicate
+	Main.wm.removeKeybinding('open-todolist');
 
 	// Key binding
 	Main.wm.addKeybinding('open-todolist',

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
   "name": "Todo list", 
   "shell-version": [
       "3.20",
+      "3.18",
       "3.16",
       "3.14"
   ], 


### PR DESCRIPTION
Hi,
Sometimes the global shortcut stops working. Already saw this using gnome 3.18.5 and 3.22.2
I can reproduce with 100% on gnome 3.18.5, after locking using GDM, the shortcut stops working.

Adding the few lines in this pull request seems to correct the issue. But I don't know much about gnome extensions so I think a quick review on this would be useful.

I also added the version 3.18 in the metadata.json, which works great on my computer.

Thank's !