### PR TITLE
Properly monitor storage when being symbolic link

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -155,7 +155,7 @@ class TodoList extends PanelMenu.Button {
 		// Conect file 'changed' signal to _refresh
 		let fileM = Gio.file_new_for_path(this.filePath);
 		let mode = Shell.ActionMode ? Shell.ActionMode.ALL : Shell.KeyBindingMode.ALL;
-		this.monitor = fileM.monitor(Gio.FileMonitorFlags.NONE, null);
+		this.monitor = fileM.monitor(Gio.FileMonitorFlags.WATCH_HARD_LINKS, null);
 		this.monitor.connect('changed', Lang.bind(this, this._refresh));
 
 		// Key binding


### PR DESCRIPTION
Currently, when you use a symbolic link for `$HOME/.list.tasks` file, everything works great, except when you remove a task:

In that case, the extension keeps displaying `(...)` because the monitor is not triggered.