### PR TITLE
Added support for Gnome 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "description": "Simple todo list extension. You can add and remove tasks on your list.",
   "name": "Todo list",
   "shell-version": [
-      "3.32"
+      "3.32", "40"
   ],
   "url": "https://github.com/bsaleil/todolist-gnome-shell-extension",
   "uuid": "todolist@bsaleil.org"


### PR DESCRIPTION
The code is compatible; only metadata.json needed update. It also should be compatible with Gnome Shell 41, but can't test it.