### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "description": "Simple todo list extension. You can add and remove tasks on your list.",
   "name": "Todo list",
   "shell-version": [
-      "3.32", "40"
+      "3.32", "40", "42"
   ],
   "url": "https://github.com/bsaleil/todolist-gnome-shell-extension",
   "uuid": "todolist@bsaleil.org"


### PR DESCRIPTION
add Gnome 42 support
quoted from previous commit :D
"The code is compatible; only metadata.json needed an update. It also should be compatible with Gnome Shell 42"